### PR TITLE
Fix: pre-commit hook not installed if hooks directory is missing

### DIFF
--- a/src/PhpcsPlugin.php
+++ b/src/PhpcsPlugin.php
@@ -13,7 +13,7 @@ class PhpcsPlugin implements PluginInterface, EventSubscriberInterface
      * @var IOInterface
      */
     private $io;
-    
+
     public static function getSubscribedEvents()
     {
         return array(
@@ -29,10 +29,18 @@ class PhpcsPlugin implements PluginInterface, EventSubscriberInterface
 
     public function installGitPreHook()
     {
-        $hooksDir = '.git/hooks';
-        if (!is_dir($hooksDir)) {
+        $gitDir = '.git';
+        $hooksDir = $gitDir . '/hooks';
+        if (!is_dir($gitDir)) {
             $this->io->isVeryVerbose() && $this->io->writeError("No .git found, not in vcs?");
             return;
+        }
+        if (!is_dir($hooksDir)) {
+            $this->io->isVeryVerbose() && $this->io->write(sprintf("%s dir not found, create it..,", $hooksDir))
+            if (!mkdir($hooksDir)) {
+              $this->io->writeError(sprintf("Unable to create %s directory.", $hooksDir))
+              return;
+            }
         }
         if (file_exists($hookFile = $hooksDir . '/pre-commit')) {
             $this->io->isVeryVerbose() && $this->io->writeError("pre-commit hook file exists, skip");


### PR DESCRIPTION
_Current situation:_
When the `.git` directory exists, but not the `.git/hooks` directory, the install script fails.

_Expected situation:_
Create the `.git/hooks` directory and complete install script.

This pull request promotes the expected situation.